### PR TITLE
ContactHist Pipeline - Enhancements and fixes

### DIFF
--- a/factory/adfadbdev001.json
+++ b/factory/adfadbdev001.json
@@ -4,7 +4,7 @@
 		"globalParameters": {
 			"environment": {
 				"type": "string",
-				"value": "prod"
+				"value": "dev"
 			},
 			"dev_resource_group": {
 				"type": "string",

--- a/factory/adfadbdev001.json
+++ b/factory/adfadbdev001.json
@@ -4,7 +4,7 @@
 		"globalParameters": {
 			"environment": {
 				"type": "string",
-				"value": "dev"
+				"value": "prod"
 			},
 			"dev_resource_group": {
 				"type": "string",

--- a/pipeline/DCL_ContactHist_Unload_MBox.json
+++ b/pipeline/DCL_ContactHist_Unload_MBox.json
@@ -1357,6 +1357,202 @@
 									"enablePartitionDiscovery": false
 								}
 							}
+						},
+						{
+							"name": "move end file to sftp",
+							"type": "Copy",
+							"dependsOn": [
+								{
+									"activity": "Delete archived zip",
+									"dependencyConditions": [
+										"Succeeded"
+									]
+								}
+							],
+							"policy": {
+								"timeout": "0.12:00:00",
+								"retry": 0,
+								"retryIntervalInSeconds": 30,
+								"secureOutput": false,
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"source": {
+									"type": "BinarySource",
+									"storeSettings": {
+										"type": "AzureBlobFSReadSettings",
+										"recursive": true,
+										"deleteFilesAfterCompletion": false
+									},
+									"formatSettings": {
+										"type": "BinaryReadSettings"
+									}
+								},
+								"sink": {
+									"type": "BinarySink",
+									"storeSettings": {
+										"type": "SftpWriteSettings",
+										"operationTimeout": "01:00:00",
+										"useTempFileRename": true
+									}
+								},
+								"enableStaging": false
+							},
+							"inputs": [
+								{
+									"referenceName": "BinarySource",
+									"type": "DatasetReference",
+									"parameters": {
+										"container": "@activity('read parameters').output.value[0].container",
+										"directory": "@{variables('parentFolder')}/@{activity('read parameters').output.value[0].target_folder_path}",
+										"sourceFile": "do_not_delete.end"
+									}
+								}
+							],
+							"outputs": [
+								{
+									"referenceName": "JPDCL_Binary_SFTP_Sink",
+									"type": "DatasetReference",
+									"parameters": {
+										"directory": "@{activity('read parameters').output.value[0].sftp_folder_path}",
+										"filename": {
+											"value": "KDP_File_@{variables('date_for_zip')}.end",
+											"type": "Expression"
+										}
+									}
+								}
+							]
+						},
+						{
+							"name": "error log - move end file",
+							"type": "ExecutePipeline",
+							"dependsOn": [
+								{
+									"activity": "move end file to sftp",
+									"dependencyConditions": [
+										"Failed"
+									]
+								}
+							],
+							"policy": {
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"pipeline": {
+									"referenceName": "write_error_log",
+									"type": "PipelineReference"
+								},
+								"waitOnCompletion": true,
+								"parameters": {
+									"process_id": {
+										"value": "@pipeline().parameters.process_id",
+										"type": "Expression"
+									},
+									"job_name": {
+										"value": "@pipeline().Pipeline",
+										"type": "Expression"
+									},
+									"error_message": {
+										"value": "@activity('move end file to sftp').error?.message",
+										"type": "Expression"
+									},
+									"run_id": {
+										"value": "@pipeline().RunId",
+										"type": "Expression"
+									},
+									"category": {
+										"value": "@pipeline().parameters.category",
+										"type": "Expression"
+									},
+									"phase_id": {
+										"value": "@pipeline().parameters.phase_id",
+										"type": "Expression"
+									},
+									"error_code": {
+										"value": "@activity('move end file to sftp').error?.errorCode",
+										"type": "Expression"
+									},
+									"job_id": {
+										"value": "@pipeline()?.TriggeredByPipelineRunId",
+										"type": "Expression"
+									}
+								}
+							}
+						},
+						{
+							"name": "Send error -move end file",
+							"type": "ExecutePipeline",
+							"dependsOn": [
+								{
+									"activity": "move end file to sftp",
+									"dependencyConditions": [
+										"Failed"
+									]
+								}
+							],
+							"policy": {
+								"secureInput": false
+							},
+							"userProperties": [],
+							"typeProperties": {
+								"pipeline": {
+									"referenceName": "NotifiyTeamsChannelPipeline",
+									"type": "PipelineReference"
+								},
+								"waitOnCompletion": true,
+								"parameters": {
+									"subscription": {
+										"value": "@if(equals(pipeline().globalParameters.environment, 'prod'),pipeline().globalParameters.prod_subscription_id, pipeline().globalParameters.dev_subscription_id)",
+										"type": "Expression"
+									},
+									"resourceGroup": {
+										"value": "@if(equals(pipeline().globalParameters.environment, 'prod'),pipeline().globalParameters.prod_resource_group, pipeline().globalParameters.dev_resource_group)",
+										"type": "Expression"
+									},
+									"runId": {
+										"value": "@pipeline().RunId",
+										"type": "Expression"
+									},
+									"name": {
+										"value": "@pipeline().Pipeline",
+										"type": "Expression"
+									},
+									"triggerTime": {
+										"value": "@pipeline().TriggerTime",
+										"type": "Expression"
+									},
+									"status": "FAIL",
+									"supportMessage": {
+										"value": "There is some issue while moving zero bytes file to SFTP : \\n\n**PROCESS_ID**:  @{pipeline().parameters.process_id}  \\n\n**CATEGORY**: @{pipeline().parameters.category} \\n\n**PHASE_ID**:   @{pipeline().parameters.phase_id}   \\n\n**USECASE_ID**: @{pipeline().parameters.usecase_id} \\n\n**SEQUENCE_ID**: @{pipeline().parameters.sequence_id} \\n\n**CONTAINER**: @{activity('read parameters').output.value[0].container} \\n\n**ZERO_BYTE_FILE_NAME**: @{variables('date_for_zip')}.end \\n\n**ERROR**: _@{activity('move end file to sftp').error?.message}_",
+										"type": "Expression"
+									},
+									"isBusinessNotification": "No",
+									"isSupportNotification": "Yes",
+									"isError": "Yes"
+								}
+							}
+						},
+						{
+							"name": "move end file error",
+							"type": "Fail",
+							"dependsOn": [
+								{
+									"activity": "move end file to sftp",
+									"dependencyConditions": [
+										"Failed"
+									]
+								}
+							],
+							"userProperties": [],
+							"typeProperties": {
+								"message": {
+									"value": "Error While moving zero bytes file into ADLS: @{activity('move end file to sftp').error?.errorCode} @{activity('move end file to sftp').error?.message}",
+									"type": "Expression"
+								},
+								"errorCode": "2000"
+							}
 						}
 					]
 				}

--- a/pipeline/DCL_ContactHist_Unload_MBox.json
+++ b/pipeline/DCL_ContactHist_Unload_MBox.json
@@ -2080,19 +2080,24 @@
 		],
 		"parameters": {
 			"category": {
-				"type": "string"
+				"type": "string",
+				"defaultValue": "test_contactHist"
 			},
 			"usecase_id": {
-				"type": "int"
+				"type": "int",
+				"defaultValue": 378
 			},
 			"phase_id": {
-				"type": "int"
+				"type": "int",
+				"defaultValue": 3
 			},
 			"sequence_id": {
-				"type": "int"
+				"type": "int",
+				"defaultValue": 1
 			},
 			"process_id": {
-				"type": "int"
+				"type": "int",
+				"defaultValue": 1978
 			}
 		},
 		"variables": {

--- a/pipeline/DCL_ContactHist_Unload_MBox.json
+++ b/pipeline/DCL_ContactHist_Unload_MBox.json
@@ -2080,24 +2080,19 @@
 		],
 		"parameters": {
 			"category": {
-				"type": "string",
-				"defaultValue": "test_contactHist"
+				"type": "string"
 			},
 			"usecase_id": {
-				"type": "int",
-				"defaultValue": 378
+				"type": "int"
 			},
 			"phase_id": {
-				"type": "int",
-				"defaultValue": 3
+				"type": "int"
 			},
 			"sequence_id": {
-				"type": "int",
-				"defaultValue": 1
+				"type": "int"
 			},
 			"process_id": {
-				"type": "int",
-				"defaultValue": 1978
+				"type": "int"
 			}
 		},
 		"variables": {

--- a/pipeline/DCL_ContactHist_Unload_MBox.json
+++ b/pipeline/DCL_ContactHist_Unload_MBox.json
@@ -1311,7 +1311,7 @@
 									"parameters": {
 										"directory": "@{activity('read parameters').output.value[0].sftp_folder_path}",
 										"filename": {
-											"value": "KDP_File_@{variables('date_for_zip')}.zip",
+											"value": "@{variables('date_for_zip')}.zip",
 											"type": "Expression"
 										}
 									}
@@ -1417,7 +1417,7 @@
 									"parameters": {
 										"directory": "@{activity('read parameters').output.value[0].sftp_folder_path}",
 										"filename": {
-											"value": "KDP_File_@{variables('date_for_zip')}.end",
+											"value": "@{variables('date_for_zip')}.end",
 											"type": "Expression"
 										}
 									}


### PR DESCRIPTION
ContactHist Pipeline - Enhancements and fixes

## Description & motivation
As requested by Saptarshi, we will be generating an empty ".end" file which is crucial for Japan business teams. We have tested this in dev already.
Also, initially KDP files were having prefix 'KDP_File' in prod SFTP, but now we are switching it over to actual file name and Saptarshi will make change on his side to move jnj files in another folder.

## To-do before merge
NA

## Screenshots:
NA

## Validation of ADF Artifacts:
done manually

## Changes to existing ADF Artifacts:
contact hist pipeline

## Checklist:

- [x] I confirmed and have no doubts that there are no confidential data, sensitive details and credentials in my code.
- [x] My pull request represents one logical piece of work.
- [x] My commits are related to the pull request and look clean.
- [ ] I have added appropriate tests and documentation to any new ADF artifacts.
- [ ] I have updated the README file.
